### PR TITLE
add directory check

### DIFF
--- a/api/services/ReportService.js
+++ b/api/services/ReportService.js
@@ -79,6 +79,10 @@ module.exports = {
         filename = 'Report-' + startDate + '-' + endDate;
       }
 
+      if (!fs.existsSync('report')) {
+        fs.mkdirSync('report');
+      }
+
       let filePath = 'report/' + filename + '.xlsx';
       var buffer = await xlsx.build(data);
       fs.writeFileSync(filePath, buffer);


### PR DESCRIPTION
Fixed Test Error

```
  1) about report service report Excel build:
     AssertionError: expected [Error: ENOENT: no such file or directory, open 'report/Report-2015-09.xlsx'] to equal 'report/Report-2015-09.xlsx'
      at Object.callee$1$0$ (test/unit/services/ReportService.spec.js:27:23)

  2) about report service report Excel build with multi sheet:
     AssertionError: expected [Error: ENOENT: no such file or directory, open 'report/Report-2015-09-2015-10.xlsx'] to equal 'report/Report-2015-09-2015-10.xlsx'
      at Object.callee$1$0$ (test/unit/services/ReportService.spec.js:68:23)
```
